### PR TITLE
fix: #734 Fixed Blank UI

### DIFF
--- a/apps/web/app/hooks/features/useAuthenticateUser.ts
+++ b/apps/web/app/hooks/features/useAuthenticateUser.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_APP_PATH } from '@app/constants';
 import { removeAuthCookies } from '@app/helpers/cookies';
 import { IUser } from '@app/interfaces/IUserData';
 import {
@@ -34,7 +35,7 @@ export const useAuthenticateUser = (defaultUser?: IUser) => {
 	const logOut = useCallback(() => {
 		removeAuthCookies();
 		window.clearInterval(intervalRt.current);
-		window.location.reload();
+		window.location.replace(DEFAULT_APP_PATH);
 	}, []);
 
 	const timeToTimeRefreshToken = useCallback((interval = 3000 * 60) => {


### PR DESCRIPTION
#734 

- [x] When the manager deletes team and press 'log out' should see the main landing page (Now nothing)
- [x] When the manager deletes own account -> should see the main landing page (Now nothing)