### PR TITLE
fix: #734 Close only rejected notification

### DIFF
--- a/apps/web/app/hooks/features/useTeamInvitations.ts
+++ b/apps/web/app/hooks/features/useTeamInvitations.ts
@@ -113,11 +113,13 @@ export function useTeamInvitations() {
 				if (action === MyInvitationActionEnum.ACCEPTED) {
 					loadTeamsData();
 				}
-				removeMyInvitation(id);
+				setMyInvitationsList(
+					myInvitationsList.filter((invitation) => invitation.id !== id)
+				);
 				return res.data;
 			});
 		},
-		[acceptRejectMyInvitationsQueryCall]
+		[acceptRejectMyInvitationsQueryCall, myInvitationsList]
 	);
 
 	return {


### PR DESCRIPTION
#734 

- [x] When a user has a few invites to join teams and clicks on ‘Reject’ on one of them, it should close only exactly that notification user ‘Rejected’ (Now it closes all notifications)