### PR TITLE
fix/#734 Redirect user to main page from public page if already member

### DIFF
--- a/apps/web/app/constants.ts
+++ b/apps/web/app/constants.ts
@@ -13,6 +13,7 @@ export const REFRESH_TOKEN_COOKIE_NAME = 'auth-refresh-token';
 export const ACTIVE_TEAM_COOKIE_NAME = 'auth-active-team';
 export const ACTIVE_TASK_COOKIE_NAME = 'auth-active-task';
 export const ACTIVE_USER_TASK_COOKIE_NAME = 'auth-user-active-task';
+export const ACTIVE_USER_ID_COOKIE_NAME = 'auth-user-id';
 export const TENANT_ID_COOKIE_NAME = 'auth-tenant-id';
 export const ORGANIZATION_ID_COOKIE_NAME = 'auth-organization-id';
 export const ACTIVE_LANGUAGE_COOKIE_NAME = 'auth-active-language';

--- a/apps/web/app/helpers/cookies.ts
+++ b/apps/web/app/helpers/cookies.ts
@@ -9,6 +9,7 @@ import {
 	ACTIVE_TIMEZONE_COOKIE_NAME,
 	ACTIVE_USER_TASK_COOKIE_NAME,
 	NO_TEAM_POPUP_SHOW_COOKIE_NAME,
+	ACTIVE_USER_ID_COOKIE_NAME,
 } from '@app/constants';
 import { IDecodedRefreshToken } from '@app/interfaces/IAuthentication';
 import { deleteCookie, getCookie, setCookie } from 'cookies-next';
@@ -26,6 +27,7 @@ type DataParams = {
 	timezone?: string;
 	languageId: string;
 	noTeamPopup?: boolean;
+	userId: string;
 };
 
 type NextCtx = { req: NextApiRequest; res: NextApiResponse };
@@ -44,6 +46,7 @@ export function setAuthCookies(
 		languageId,
 		// timezone,
 		noTeamPopup,
+		userId,
 	} = datas;
 
 	// const expires = addHours(6, changeTimezone(new Date(), timezone));
@@ -55,6 +58,7 @@ export function setAuthCookies(
 	setCookie(ORGANIZATION_ID_COOKIE_NAME, organizationId, { res, req });
 	setCookie(ACTIVE_LANGUAGE_COOKIE_NAME, languageId, { res, req });
 	setCookie(NO_TEAM_POPUP_SHOW_COOKIE_NAME, noTeamPopup, { res, req });
+	setCookie(ACTIVE_USER_ID_COOKIE_NAME, userId, { res, req });
 }
 
 export function cookiesKeys() {
@@ -68,6 +72,7 @@ export function cookiesKeys() {
 		ACTIVE_LANGUAGE_COOKIE_NAME,
 		NO_TEAM_POPUP_SHOW_COOKIE_NAME,
 		ACTIVE_USER_TASK_COOKIE_NAME,
+		ACTIVE_USER_ID_COOKIE_NAME,
 	];
 }
 
@@ -120,6 +125,15 @@ export function getActiveTaskIdCookie(ctx?: NextCtx) {
 
 export function setActiveTaskIdCookie(taskId: string, ctx?: NextCtx) {
 	return setCookie(ACTIVE_TASK_COOKIE_NAME, taskId, { ...(ctx || {}) });
+}
+
+// Active userId
+export function getActiveUserIdCookie(ctx?: NextCtx) {
+	return getCookie(ACTIVE_USER_ID_COOKIE_NAME, { ...(ctx || {}) }) as string;
+}
+
+export function setActiveUserIdCookie(userId: string, ctx?: NextCtx) {
+	return setCookie(ACTIVE_USER_ID_COOKIE_NAME, userId, { ...(ctx || {}) });
 }
 
 export function getNoTeamPopupShowCookie(ctx?: NextCtx) {

--- a/apps/web/app/hooks/features/usePublicOrganizationTeams.ts
+++ b/apps/web/app/hooks/features/usePublicOrganizationTeams.ts
@@ -1,13 +1,16 @@
 import { getPublicOrganizationTeamsAPI } from '@app/services/client/api/public-organization-team';
+import { publicactiveTeamState } from '@app/stores';
 import { useCallback } from 'react';
+import { useRecoilState } from 'recoil';
 import { useQuery } from '../useQuery';
 import { useOrganizationTeams } from './useOrganizationTeams';
 import { useTeamTasks } from './useTeamTasks';
 
 export function usePublicOrganizationTeams() {
 	const { loading, queryCall } = useQuery(getPublicOrganizationTeamsAPI);
-	const { setTeams } = useOrganizationTeams();
+	const { activeTeam, setTeams } = useOrganizationTeams();
 	const { setAllTasks } = useTeamTasks();
+	const [publicTeam, setPublicTeam] = useRecoilState(publicactiveTeamState);
 
 	const loadPublicTeamData = useCallback(
 		(profileLink: string, teamId: string) => {
@@ -18,6 +21,7 @@ export function usePublicOrganizationTeams() {
 				}
 
 				setTeams([res.data.data]);
+				setPublicTeam(res.data.data);
 				setAllTasks(res?.data?.data?.tasks || []);
 				return res;
 			});
@@ -28,5 +32,7 @@ export function usePublicOrganizationTeams() {
 	return {
 		loadPublicTeamData,
 		loading,
+		activeTeam,
+		publicTeam,
 	};
 }

--- a/apps/web/app/stores/organization-team.ts
+++ b/apps/web/app/stores/organization-team.ts
@@ -42,6 +42,11 @@ export const activeTeamState = selector<IOrganizationTeamList | null>({
 	},
 });
 
+export const publicactiveTeamState = atom<IOrganizationTeamList | undefined>({
+	key: 'publicactiveTeamState',
+	default: undefined,
+});
+
 export const activeTeamManagersState = selector<OT_Member[]>({
 	key: 'activeTeamManagersState',
 	get: ({ get }) => {

--- a/apps/web/pages/api/auth/login.ts
+++ b/apps/web/pages/api/auth/login.ts
@@ -163,6 +163,7 @@ export default async function handler(
 			organizationId: organization?.organizationId,
 			languageId: 'en', // TODO: not sure what should be here
 			noTeamPopup: true,
+			userId,
 		},
 		req,
 		res

--- a/apps/web/pages/api/auth/register.ts
+++ b/apps/web/pages/api/auth/register.ts
@@ -15,7 +15,10 @@ import {
 import { NextApiRequest, NextApiResponse } from 'next';
 import { setAuthCookies } from '@app/helpers/cookies';
 import { recaptchaVerification } from '@app/services/server/recaptcha';
-import { RECAPTCHA_SECRET_KEY, VERIFY_EMAIL_CALLBACK_PATH } from '@app/constants';
+import {
+	RECAPTCHA_SECRET_KEY,
+	VERIFY_EMAIL_CALLBACK_PATH,
+} from '@app/constants';
 
 export default async function handler(
 	req: NextApiRequest,
@@ -139,6 +142,7 @@ export default async function handler(
 			tenantId: tenant.id,
 			organizationId: organization.id,
 			languageId: 'en', // TODO: not sure what should be here
+			userId: user.id,
 		},
 		req,
 		res

--- a/apps/web/pages/team/[teamId]/[profileLink].tsx
+++ b/apps/web/pages/team/[teamId]/[profileLink].tsx
@@ -1,3 +1,4 @@
+import { getActiveUserIdCookie } from '@app/helpers';
 import { usePublicOrganizationTeams } from '@app/hooks/features/usePublicOrganizationTeams';
 import { publicState } from '@app/stores/public';
 import { Breadcrumb, Container } from 'lib/components';
@@ -11,9 +12,22 @@ import { useRecoilState } from 'recoil';
 const Team = () => {
 	const router = useRouter();
 	const query = router.query;
-	const { loadPublicTeamData } = usePublicOrganizationTeams();
+	const { loadPublicTeamData, publicTeam: publicTeamData } =
+		usePublicOrganizationTeams();
 	const { trans } = useTranslation('home');
 	const [publicTeam, setPublic] = useRecoilState(publicState);
+
+	useEffect(() => {
+		const userId = getActiveUserIdCookie();
+
+		if (
+			userId &&
+			publicTeamData &&
+			publicTeamData.members.find((member) => member.employee.userId === userId)
+		) {
+			router.replace('/');
+		}
+	}, [publicTeamData, router]);
 
 	useEffect(() => {
 		if (query && query.teamId && query.profileLink) {


### PR DESCRIPTION
### Issue #734 

- [x] Public page - if user presses 'Requested join' (but has an account) should select Tab 'Already Member' and with own email join and see the normal page as if the user Login from the main landing page (now the user can see Public page only)