### PR TITLE
fix: #734 Public Team should be selected by default

### DIFF
--- a/apps/web/pages/api/auth/register.ts
+++ b/apps/web/pages/api/auth/register.ts
@@ -122,6 +122,7 @@ export default async function handler(
 			tenantId: tenant.id,
 			organizationId: organization.id,
 			managerIds: [employee.id],
+			public: true, // By default team should be public
 		},
 		auth_token
 	);

--- a/apps/web/pages/api/organization-team/index.ts
+++ b/apps/web/pages/api/organization-team/index.ts
@@ -29,6 +29,7 @@ export default async function handler(
 				tenantId,
 				organizationId,
 				managerIds: [user.employee.id],
+				public: true, // By default team should be public
 			},
 			access_token
 		);


### PR DESCRIPTION
### Task - 734

- [x] Settings / Team - Public Team should be selected by default