### PR TITLE
fix: #734 Empty Main input on unassign task

### DIFF
--- a/apps/web/app/hooks/features/useTeamTasks.ts
+++ b/apps/web/app/hooks/features/useTeamTasks.ts
@@ -115,6 +115,11 @@ export function useTeamTasks() {
 					taskId: task?.id,
 					userId: authUser.current?.id,
 				});
+			} else {
+				setActiveUserTaskCookie({
+					taskId: '',
+					userId: '',
+				});
 			}
 		},
 		[authUser.current]


### PR DESCRIPTION
### Task - #734 

- [x]  Team page / Unassign task from yourself - the main input should become empty (now it still shows the assigned task data)
