### PR TITLE
fix: #734 Increased Size of task titles

### DIFF
--- a/apps/web/lib/features/task/task-displays.tsx
+++ b/apps/web/lib/features/task/task-displays.tsx
@@ -20,10 +20,12 @@ export function TaskNameInfoDisplay({ task }: { task: Nullable<ITeamTask> }) {
 								task={task}
 							/>
 						</div>
-						<span className="text-gray-500 mr-2">#{task.taskNumber}</span>
+						<span className="text-gray-500 mr-1 font-normal">
+							#{task.taskNumber}
+						</span>
 					</div>
 				)}
-				{task?.title}
+				<span className="font-normal">{task?.title}</span>
 			</span>
 		</Tooltip>
 	);


### PR DESCRIPTION
### TASK: #734 

- [x]  the Size of Status, Labels, Priorities are still bigger than task titles etc
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/81486442/231756961-acec112e-76d5-4e83-a3b0-4771cd31fbf2.png">
