### PR TITLE
fix: #734 Handled Avatar non-string Image URL

### DIFF
--- a/apps/web/lib/components/avatar.tsx
+++ b/apps/web/lib/components/avatar.tsx
@@ -24,7 +24,8 @@ export function Avatar({
 }: Props) {
 	const [avatar, setAvatar] = useRecoilState(avatarState);
 
-	const imagePathName = imageUrl ? new URL(imageUrl || '').pathname : '';
+	const imagePathName =
+		imageUrl && typeof imageUrl === 'string' ? new URL(imageUrl).pathname : '';
 	const avatarPresent = Object.hasOwn(avatar, imagePathName);
 
 	const imgUrl = useMemo(() => {


### PR DESCRIPTION
### Task: #734 

- [x] App Crashing when the user is not part of any Team

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/81486442/231967722-314be2f2-d2f9-4f18-baf3-f895e0b4b69e.png">
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/81486442/231967760-44a6ee2f-d768-4767-9497-d7fef953a3f4.png">
