### PR TITLE
fix: #734 Refresh token on Remove account

### DIFF
--- a/apps/web/app/hooks/features/useOrganizationTeams.ts
+++ b/apps/web/app/hooks/features/useOrganizationTeams.ts
@@ -186,6 +186,7 @@ export function useOrganizationTeams() {
 	const [teamsFetching, setTeamsFetching] = useRecoilState(teamsFetchingState);
 	const { firstLoad, firstLoadData: firstLoadTeamsData } = useFirstLoad();
 	const [isTeamMember, setIsTeamMember] = useRecoilState(isTeamMemberState);
+	const { updateUserFromAPI, refreshToken } = useAuthenticateUser();
 
 	// Updaters
 	const { createOrganizationTeam, loading: createOTeamLoading } =
@@ -330,6 +331,10 @@ export function useOrganizationTeams() {
 		(userId: string) => {
 			return removeUserFromAllTeamQueryCall(userId).then((res) => {
 				loadTeamsData();
+				refreshToken().then(() => {
+					updateUserFromAPI();
+				});
+
 				return res;
 			});
 		},


### PR DESCRIPTION
### Task #734 

- [x]  When the manager tries to 'Remove account' from all teams (within one tenant/workspace) -> should be able to remove from all teams where the user is not a manager
