### PR TITLE
fix: #734 Hide user card if time tracking is disable for manager

### DIFF
--- a/apps/web/lib/features/team-members.tsx
+++ b/apps/web/lib/features/team-members.tsx
@@ -16,7 +16,13 @@ import InviteUserTeamCardSkeleton from '@components/shared/skeleton/InviteTeamCa
 import { UserCard } from '@components/shared/skeleton/TeamPageSkeleton';
 // import { useEffect } from 'react';
 
-export function TeamMembers({ publicTeam = false }: { publicTeam?: boolean }) {
+export function TeamMembers({
+	publicTeam = false,
+	isTrackingEnabled = true,
+}: {
+	publicTeam?: boolean;
+	isTrackingEnabled?: boolean;
+}) {
 	const { isTeamManager, user } = useAuthenticateUser();
 	const { activeTeam, teamsFetching } = useOrganizationTeams();
 	const { teamInvitations } = useTeamInvitations();
@@ -47,7 +53,7 @@ export function TeamMembers({ publicTeam = false }: { publicTeam?: boolean }) {
 		<ul className="mt-7">
 			{/* Current authenticated user members */}
 			<Transition
-				show={!!currentUser}
+				show={!!currentUser && isTrackingEnabled}
 				enter="transition-opacity duration-75"
 				enterFrom="opacity-0"
 				enterTo="opacity-100"

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -42,7 +42,11 @@ function MainPage() {
 			</MainHeader>
 
 			<Container className="mb-10">
-				{isTeamMember ? <TeamMembers /> : <NoTeam />}
+				{isTeamMember ? (
+					<TeamMembers isTrackingEnabled={isTrackingEnabled} />
+				) : (
+					<NoTeam />
+				)}
 			</Container>
 		</MainLayout>
 	);


### PR DESCRIPTION
### Task - https://github.com/ever-co/ever-gauzy-teams/issues/734

- [ ] Team page - if a user (manager) disabled Time tracking, User task card should NOT be displayed on Team page