### PR TITLE
fix: #734 Handled re render of Task Status,Size,Priority,Label input

### DIFF
--- a/apps/web/app/hooks/features/useTaskLabels.ts
+++ b/apps/web/app/hooks/features/useTaskLabels.ts
@@ -54,7 +54,7 @@ export function useTaskLabels() {
 
 			return res;
 		});
-	}, [user, activeTeamId, setTaskLabels]);
+	}, [user, activeTeamId, setTaskLabels, taskLabels]);
 
 	useEffect(() => {
 		if (!firstLoad) return;

--- a/apps/web/app/hooks/features/useTaskPriorities.ts
+++ b/apps/web/app/hooks/features/useTaskPriorities.ts
@@ -57,7 +57,7 @@ export function useTaskPriorities() {
 
 			return res;
 		});
-	}, [user, activeTeamId, setTaskPriorities]);
+	}, [user, activeTeamId, setTaskPriorities, taskPriorities]);
 
 	useEffect(() => {
 		if (!firstLoad) return;

--- a/apps/web/app/hooks/features/useTaskSizes.ts
+++ b/apps/web/app/hooks/features/useTaskSizes.ts
@@ -54,7 +54,7 @@ export function useTaskSizes() {
 
 			return res;
 		});
-	}, [user, activeTeamId, setTaskSizes]);
+	}, [user, activeTeamId, setTaskSizes, taskSizes]);
 
 	useEffect(() => {
 		if (!firstLoad) return;

--- a/apps/web/app/hooks/features/useTaskStatus.ts
+++ b/apps/web/app/hooks/features/useTaskStatus.ts
@@ -52,7 +52,7 @@ export function useTaskStatus() {
 			}
 			return res;
 		});
-	}, [user, activeTeamId, setTaskStatus]);
+	}, [user, activeTeamId, setTaskStatus, taskStatus]);
 
 	useEffect(() => {
 		if (!firstLoad) return;

--- a/apps/web/app/hooks/features/useTeamTasks.ts
+++ b/apps/web/app/hooks/features/useTeamTasks.ts
@@ -229,7 +229,7 @@ export function useTeamTasks() {
 			task?: ITeamTask | null,
 			loader?: boolean
 		) => {
-			if (task && status !== task.status) {
+			if (task && status !== task[field]) {
 				loader && setTasksFetching(true);
 
 				if (field === 'status' && status === 'closed') {


### PR DESCRIPTION
### Task - https://github.com/ever-co/ever-gauzy-teams/issues/734

- [x] Input of Task Status, Size, Priority and Label automatically removed every 5 seconds


**BEFORE**
[rerender-before.webm](https://user-images.githubusercontent.com/81486442/234761810-0b5f1230-e304-4d74-9236-0561bf55b8f8.webm)

**AFTER**
[rerender-after.webm](https://user-images.githubusercontent.com/81486442/234761853-6370111d-5759-4ed6-ab50-4eca20c8d95c.webm)
