### PR TITLE
fix: #734 Timer button disabled unnecessarily

### DIFF
--- a/apps/web/app/hooks/features/useTimer.ts
+++ b/apps/web/app/hooks/features/useTimer.ts
@@ -360,6 +360,7 @@ export function useTimerView() {
 		canRunTimer,
 		timerSeconds,
 		activeTeamTask,
+		syncTimerLoading,
 	} = useTimer();
 
 	const { activeTaskEstimation } = useTaskStatistics(timerSeconds);
@@ -384,9 +385,10 @@ export function useTimerView() {
 		timerStatusFetching,
 		timerStatus,
 		activeTeamTask,
-		disabled: timerStatusFetching || !canRunTimer,
+		disabled: !canRunTimer,
 		startTimer,
 		stopTimer,
+		syncTimerLoading,
 	};
 }
 

--- a/apps/web/lib/features/timer/timer.tsx
+++ b/apps/web/lib/features/timer/timer.tsx
@@ -15,7 +15,6 @@ export function Timer({ className }: IClassName) {
 		activeTaskEstimation,
 		ms_p,
 		canRunTimer,
-		timerStatusFetching,
 		timerHanlder,
 		timerStatus,
 		disabled,
@@ -48,7 +47,7 @@ export function Timer({ className }: IClassName) {
 					enabled={!canRunTimer}
 				>
 					<TimerButton
-						onClick={!timerStatusFetching ? timerHanlder : undefined}
+						onClick={timerHanlder}
 						running={timerStatus?.running}
 						disabled={disabled}
 					/>
@@ -64,10 +63,10 @@ export function MinTimerFrame({ className }: IClassName) {
 		minutes,
 		seconds,
 		ms_p,
-		canRunTimer,
-		timerStatusFetching,
+
 		timerHanlder,
 		timerStatus,
+		disabled,
 	} = useTimerView();
 
 	return (
@@ -87,9 +86,9 @@ export function MinTimerFrame({ className }: IClassName) {
 
 			<div className="ml-5 z-[50]">
 				<TimerButton
-					onClick={!timerStatusFetching ? timerHanlder : undefined}
+					onClick={timerHanlder}
 					running={timerStatus?.running}
-					disabled={timerStatusFetching || !canRunTimer}
+					disabled={disabled}
 					className="w-7 h-7"
 				/>
 			</div>


### PR DESCRIPTION
### Task - https://github.com/ever-co/ever-gauzy-teams/issues/734

- [x]  'Start/Stop' button works not well. Sometimes when the user wants to stop the button it is not clickable and vice versa. As the additional button does not change status of the button to Stop or Play


**Before**
[timer-button-before.webm](https://user-images.githubusercontent.com/81486442/235097409-debfc635-1e04-41b3-a46d-98a7b14d808b.webm)

**After**
[timer-button-after.webm](https://user-images.githubusercontent.com/81486442/235097436-51046bf5-0c4b-447a-8cef-15cae70a8e55.webm)
