### PR TITLE
fix/#734 Wrong estimation for current active task

### DIFF
--- a/apps/web/lib/features/team/user-team-card/task-estimate.tsx
+++ b/apps/web/lib/features/team/user-team-card/task-estimate.tsx
@@ -52,9 +52,7 @@ function TaskEstimateInput({
 	};
 	edition.estimateEditIgnoreElement.onOutsideClick(closeFn);
 
-	const { h, m } = secondsToTime(
-		memberInfo.member?.lastWorkedTask?.estimate || task?.estimate || 0
-	);
+	const { h, m } = secondsToTime(task?.estimate || 0);
 
 	return (
 		<>


### PR DESCRIPTION
### TASK - https://github.com/ever-co/ever-gauzy-teams/issues/734

- [x] Team page - Wrong Task Estimation is showing for current active task

**BEFORE**
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/81486442/235288528-2db59091-9284-406a-b160-1f51dc09451c.png">


**AFTER**
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/81486442/235288517-404e5608-6303-49a7-9b2d-476e78363aa8.png">


