### PR TITLE
fix: #734 Refresh token on user accept invitation to new Team

### DIFF
--- a/apps/web/app/hooks/features/useTeamInvitations.ts
+++ b/apps/web/app/hooks/features/useTeamInvitations.ts
@@ -19,7 +19,6 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { useFirstLoad } from '../useFirstLoad';
 import { useQuery } from '../useQuery';
 import { useAuthenticateUser } from './useAuthenticateUser';
-import { useOrganizationTeams } from './useOrganizationTeams';
 
 export function useTeamInvitations() {
 	const setTeamInvitations = useSetRecoilState(teamInvitationsState);
@@ -35,8 +34,7 @@ export function useTeamInvitations() {
 	const { firstLoad, firstLoadData: firstLoadTeamInvitationsData } =
 		useFirstLoad();
 
-	const { isTeamManager } = useAuthenticateUser();
-	const { loadTeamsData } = useOrganizationTeams();
+	const { isTeamManager, refreshToken } = useAuthenticateUser();
 
 	// Queries
 	const { queryCall, loading } = useQuery(getTeamInvitationsAPI);
@@ -111,7 +109,9 @@ export function useTeamInvitations() {
 				}
 
 				if (action === MyInvitationActionEnum.ACCEPTED) {
-					loadTeamsData();
+					refreshToken().then(() => {
+						window.location.reload();
+					});
 				}
 				setMyInvitationsList(
 					myInvitationsList.filter((invitation) => invitation.id !== id)


### PR DESCRIPTION
# Task - https://github.com/ever-co/ever-gauzy-teams/issues/734

- [x] Invitation, if user A is online can see the invite inside the app, when user A invited first time to Team 1 it works, if the user A was removed form the team, second time does not see an invite from the same team